### PR TITLE
#7 Add support for escaping quotes with a \

### DIFF
--- a/src/main/javacc/RSQLParser.jj
+++ b/src/main/javacc/RSQLParser.jj
@@ -67,10 +67,10 @@ TOKEN : {
 
 TOKEN : {
     < UNRESERVED_STR    : ( ~["\"", "'", "(", ")", ";", ",", "=", "<", ">", "!", "~", " "] )+ >
-  | < SINGLE_QUOTED_STR : ( "'" ( ~["'"] )* "'" ) > {
+  | < SINGLE_QUOTED_STR : ( "'" ( "\\" ~[] | ~["'", "\\"] )* "'" ) > {
         matchedToken.image = image.substring(1, image.length() -1);
     }
-  | < DOUBLE_QUOTED_STR : ( "\"" ( ~["\""] )* "\"" ) > {
+  | < DOUBLE_QUOTED_STR : ( "\"" ( "\\" ~[] | ~["\"", "\\"] )* "\"" ) > {
         matchedToken.image = image.substring(1, image.length() -1);
     }
 }

--- a/src/test/groovy/cz/jirutka/rsql/parser/RSQLParserTest.groovy
+++ b/src/test/groovy/cz/jirutka/rsql/parser/RSQLParserTest.groovy
@@ -124,6 +124,21 @@ class RSQLParserTest extends Specification {
             input << [ '"hi there!"', "'Pěkný den!'", '"Flynn\'s *"', '"o)\'O\'(o"', '"6*7=42"', '"\\(^_^)/"' ]
     }
 
+    def 'parse escaped quoted argument: #input'() {
+        given:
+        def expected = eq('sel', input[1..-2])
+        expect:
+        parse("sel==${input}") == expected
+        where:
+        input << [
+                '"hi \\\"there!"',
+                '"hey \\\\\\\"there!"',
+                '\'hi \\\'there!\'',
+                '\'she "said" it\\\'s mine\'',
+                '"i \\\"agreed\\\" that it\'s hers"'
+        ]
+    }
+
     def 'parse arguments group: #input'() {
         setup: 'strip quotes'
             def values = input.collect { val ->


### PR DESCRIPTION
@jirutka  Fixes for #7

Improved the quote_str regular expressions based on advice from http://stackoverflow.com/questions/24156948/javacc-quote-with-escape-character and added some tests to cover quoted strings.