### PR TITLE
Added support for whitespace around operators

### DIFF
--- a/src/main/java/cz/jirutka/rsql/parser/ast/ComparisonOperator.java
+++ b/src/main/java/cz/jirutka/rsql/parser/ast/ComparisonOperator.java
@@ -32,7 +32,7 @@ import static cz.jirutka.rsql.parser.ast.StringUtils.isBlank;
 @Immutable
 public final class ComparisonOperator {
 
-    private static final Pattern SYMBOL_PATTERN = Pattern.compile("=[a-zA-Z]*=|[><]=?|!=");
+    private static final Pattern SYMBOL_PATTERN = Pattern.compile("[\\s=][a-zA-Z]*[\\s=]|[><]=?|!=");
 
     private final String[] symbols;
 

--- a/src/main/javacc/RSQLParser.jj
+++ b/src/main/javacc/RSQLParser.jj
@@ -94,7 +94,7 @@ TOKEN : {
   | < OR         : ( "," | " or " ) >
   | < LPAREN     : "(" >
   | < RPAREN     : ")" >
-  | < COMP_FIQL  : ( ( "=" (<ALPHA>)* ) | "!" ) "=" >
+  | < COMP_FIQL  : ( ( [" ","="] (<ALPHA>)* ) | "!" ) [" ","="] >
   | < COMP_ALT   : ( ">" | "<" ) ( "=" )? >
 }
 


### PR DESCRIPTION
I need rsql in one of my tasks. I've found this library very useful but could not pass the regexp verification when adding a new operator with whitespaces (ex.: ' eq '). So I've changed the source code a bit.
Example query: "fullName eq 'Bob Marley'"